### PR TITLE
adding option scale to groupPlot

### DIFF
--- a/ShapeAnalysis/python/PlotFactory.py
+++ b/ShapeAnalysis/python/PlotFactory.py
@@ -481,9 +481,19 @@ class PlotFactory:
               for sampleNameGroup, sampleConfiguration in groupPlot.iteritems():
                 if sampleName in sampleConfiguration['samples']:
                   if sampleNameGroup in histos_grouped.keys() :
-                    histos_grouped[sampleNameGroup].Add(histos[sampleName])
+                    if 'scale' not in sampleConfiguration.keys() :
+                      histos_grouped[sampleNameGroup].Add(histos[sampleName])
+                    else :
+                      histo_scaled = histos[sampleName].Clone(sampleName + '_scaled')
+                      histo_scaled.Scale(sampleConfiguration['scale'][sampleName])
+                      histos_grouped[sampleNameGroup].Add(histo_scaled)
                   else :
-                    histos_grouped[sampleNameGroup] = histos[sampleName].Clone('new_histo_group_' + sampleNameGroup + '_' + cutName + '_' + variableName)
+                    if 'scale' not in sampleConfiguration.keys() :
+                      histos_grouped[sampleNameGroup] = histos[sampleName].Clone('new_histo_group_' + sampleNameGroup + '_' + cutName + '_' + variableName)
+                    else :
+                      histo_scaled = histos[sampleName].Clone(sampleName + '_scaled')
+                      histo_scaled.Scale(sampleConfiguration['scale'][sampleName])
+                      histos_grouped[sampleNameGroup] = histo_scaled.Clone('new_histo_group_' + sampleNameGroup + '_' + cutName + '_' + variableName)
 
             # end sample loop
 


### PR DESCRIPTION
The option "scale" gives the possibility to scale each sample in groupPlot by a given factor.
If the same sample appears in different groupPlots, it can be scaled each time by a different factor.

Example:

k1 = 0.1; k2 = 0.5;
groupPlot['EFT_k1'] = {
  'nameHR' : 'cqq11 = 0.1',
  'samples' : ['sm','lin_cqq11','quad_cqq11'],
  'scale' : {
    'sm' : 1,
    'lin_cqq11' : k1,
    'quad_cqq11' : k1*k1,
   }
}

groupPlot['EFT_k2'] = {
  'nameHR' : 'cqq11 = 0.5',
  'samples' : ['sm','lin_cqq11','quad_cqq11'],
  'scale' : {
    'sm' : 1,
    'lin_cqq11' : k2,
    'quad_cqq11' : k2*k2,
   }
}
